### PR TITLE
Fix callout block rendering and add missing Obsidian callout types

### DIFF
--- a/client/components/toastui/obsidianPlugin.js
+++ b/client/components/toastui/obsidianPlugin.js
@@ -11,19 +11,28 @@ function getCalloutType(text) {
   return CALLOUT_TYPES.includes(t) ? t : null;
 }
 
+function blockQuoteFirstText(node) {
+  const firstChild = node.firstChild;
+  if (firstChild?.type === "paragraph") {
+    const fc = firstChild.firstChild;
+    if (fc) return fc.literal ?? "";
+  }
+  return "";
+}
+
 export const obsidianCustomHTMLRenderer = {
   blockQuote(node, { entering, origin }) {
+    const calloutType = getCalloutType(blockQuoteFirstText(node));
     if (!entering) {
-      return { type: "closeTag", tagName: "div" };
+      if (calloutType) {
+        // Close callout-body then the outer callout div
+        return [
+          { type: "closeTag", tagName: "div" },
+          { type: "closeTag", tagName: "div" },
+        ];
+      }
+      return origin?.() ?? { type: "closeTag", tagName: "blockquote" };
     }
-    // Look at first child paragraph's first text node
-    let firstText = "";
-    const firstChild = node.firstChild;
-    if (firstChild && firstChild.type === "paragraph") {
-      const fc = firstChild.firstChild;
-      if (fc) firstText = fc.literal ?? "";
-    }
-    const calloutType = getCalloutType(firstText);
     if (calloutType) {
       return {
         type: "openTag",
@@ -36,21 +45,22 @@ export const obsidianCustomHTMLRenderer = {
   },
 
   paragraph(node, { entering, origin }) {
-    if (!entering) return origin?.();
-    // Check if parent is a blockquote and this is the first paragraph (callout title)
     const parent = node.parent;
     if (parent?.type === "blockQuote" && parent.firstChild === node) {
       const fc = node.firstChild;
       const text = fc?.literal ?? "";
       const calloutType = getCalloutType(text);
       if (calloutType) {
-        // Render callout title then suppress default paragraph — return multiple tokens
+        // On exit, emit nothing — callout-body is closed by blockQuote's exit handler
+        if (!entering) return [];
         const icon = CALLOUT_ICONS[calloutType] ?? "";
         const label = calloutType.charAt(0).toUpperCase() + calloutType.slice(1);
-        // Strip the [!TYPE] prefix from rendering
+        const titleMatch = text.match(/^\[!\w+\]\s*(.*)/si);
+        const titleExtra = titleMatch?.[1]?.trim() ?? "";
+        const titleContent = titleExtra ? `${icon} ${label} — ${escapeHtml(titleExtra)}` : `${icon} ${label}`;
         return [
           { type: "openTag", tagName: "div", attributes: { class: "callout-title" }, selfClose: false },
-          { type: "html", content: `${icon} ${label}` },
+          { type: "html", content: titleContent },
           { type: "closeTag", tagName: "div" },
           { type: "openTag", tagName: "div", attributes: { class: "callout-body" }, selfClose: false },
         ];
@@ -62,6 +72,16 @@ export const obsidianCustomHTMLRenderer = {
   // Wikilinks and image embeds: post-process text nodes for [[...]] and ![[...]] patterns
   text(node, { origin }) {
     const literal = node.literal ?? "";
+    // Suppress the [!TYPE] title text — already rendered in the callout-title div
+    if (
+      node.parent?.type === "paragraph" &&
+      node.parent.parent?.type === "blockQuote" &&
+      node.parent.parent.firstChild === node.parent &&
+      node.parent.firstChild === node &&
+      getCalloutType(literal)
+    ) {
+      return { type: "html", content: "" };
+    }
     if (!literal.includes("[[")) return origin?.();
 
     const parts = [];

--- a/client/components/toastui/obsidianPlugin.js
+++ b/client/components/toastui/obsidianPlugin.js
@@ -1,14 +1,25 @@
-const CALLOUT_TYPES = ["note", "tip", "warning", "danger", "info", "success", "question", "abstract", "bug", "example", "quote"];
+const CALLOUT_TYPES = ["note", "tip", "warning", "danger", "info", "success", "question", "abstract", "bug", "example", "quote", "okey", "error", "todo", "failure"];
+const CALLOUT_ALIASES = {
+  summary: "abstract", tldr: "abstract",
+  hint: "tip", important: "tip",
+  check: "success", done: "success",
+  help: "question", faq: "question",
+  caution: "warning", attention: "warning",
+  cite: "quote",
+  fail: "failure", missing: "failure",
+};
 const CALLOUT_ICONS = {
   note: "📝", tip: "💡", warning: "⚠️", danger: "🔥", info: "ℹ️",
   success: "✅", question: "❓", abstract: "📋", bug: "🐛", example: "📖", quote: "💬",
+  okey: "✔️", error: "❌", todo: "☑️", failure: "✖️",
 };
 
 function getCalloutType(text) {
   const m = text.match(/^\[!(\w+)\]/i);
   if (!m) return null;
   const t = m[1].toLowerCase();
-  return CALLOUT_TYPES.includes(t) ? t : null;
+  if (CALLOUT_TYPES.includes(t)) return t;
+  return CALLOUT_ALIASES[t] ?? null;
 }
 
 function blockQuoteFirstText(node) {

--- a/client/components/toastui/toastui-editor-overrides.scss
+++ b/client/components/toastui/toastui-editor-overrides.scss
@@ -328,6 +328,10 @@
   &.callout-bug     { border-left-color: #f38ba8; .callout-title { color: #f38ba8; } }
   &.callout-example { border-left-color: #cba6f7; .callout-title { color: #cba6f7; } }
   &.callout-quote   { border-left-color: #a6adc8; .callout-title { color: #a6adc8; } }
+  &.callout-okey    { border-left-color: #94e2d5; .callout-title { color: #94e2d5; } }
+  &.callout-error   { border-left-color: #f38ba8; .callout-title { color: #f38ba8; } }
+  &.callout-todo    { border-left-color: #89b4fa; .callout-title { color: #89b4fa; } }
+  &.callout-failure { border-left-color: #f38ba8; .callout-title { color: #f38ba8; } }
 }
 
 // Frontmatter display


### PR DESCRIPTION
Title: Fix callout block rendering and add missing Obsidian callout types

Body:

## Summary

- Fixes consecutive callout blocks nesting inside each other
- Adds missing Obsidian callout types and aliases

## What was broken

Consecutive callouts were nesting inside each other because the custom `blockQuote` renderer only emitted one `</div>` on exit, closing `callout-body` but leaving the outer `.callout` div unclosed. This caused each subsequent callout to render inside the previous one.

Two related issues were also fixed:
- The raw `[!TYPE]` text was leaking into the callout body even though the   title div already displayed the label
- The title paragraph emitted a mismatched `</p>` close tag (a `<div>` had   been opened instead)
- Inline titles — e.g. `> [!INFO] Custom title` — are now shown in the   callout header rather than dropped into the body

## New callout types

Added `todo` and `failure` as new types, plus all missing Obsidian aliases:

| Alias(es) | Resolves to |
|---|---|
| `summary`, `tldr` | `abstract` |
| `hint`, `important` | `tip` |
| `check`, `done` | `success` |
| `help`, `faq` | `question` |
| `caution`, `attention` | `warning` |
| `cite` | `quote` |
| `fail`, `missing` | `failure` |